### PR TITLE
Updates from last night

### DIFF
--- a/lib/build-cloud.rb
+++ b/lib/build-cloud.rb
@@ -31,8 +31,9 @@ class BuildCloud
             include_path = File.join( File.dirname( options[:config] ), include_file)
 
             if File.exists?( include_path )
-               included_conf = YAML::load( File.open( include_path ) )
-               @config = @config.merge( included_conf )
+                @log.info( "Including YAML file #{include_path}" )
+                included_conf = YAML::load( File.open( include_path ) )
+                @config = @config.merge( included_conf )
             end
 
         end

--- a/lib/build-cloud/instance.rb
+++ b/lib/build-cloud/instance.rb
@@ -32,7 +32,7 @@ class BuildCloud::Instance
 
         @log.debug( options.inspect )
 
-        required_options(:image_id, :flavor_id, :private_ip_address, :name)
+        required_options(:image_id, :flavor_id, :name)
         require_one_of(:security_group_ids, :security_group_names, :network_interfaces)
         require_one_of(:subnet_id, :subnet_name, :network_interfaces)
         #require_one_of(:network_interfaces, :private_ip_address)

--- a/lib/build-cloud/networkinterface.rb
+++ b/lib/build-cloud/networkinterface.rb
@@ -85,6 +85,7 @@ class BuildCloud::NetworkInterface
             public_ip = ip.public_ip
             allocation_id = ip.allocation_id
             @compute.associate_address(nil, nil, interface.network_interface_id, allocation_id )
+            @log.info( "Assigned new public IP #{public_ip}" )
         end
 
         unless options[:existing_public_ip].nil?

--- a/lib/build-cloud/subnet.rb
+++ b/lib/build-cloud/subnet.rb
@@ -53,14 +53,18 @@ class BuildCloud::Subnet
         subnet = @compute.subnets.new( options )
         subnet.save
 
-        options[:tag_set].each do | tag |
-            attributes = {}
-            attributes[:resource_id] = subnet.subnet_id.to_s
-            attributes[:key] = tag[:key]
-            attributes[:value] = tag[:value]
-            new_tag = @compute.tags.new( attributes )
-            new_tag.save
-        end unless options[:tag_set].empty? or options[:tag_set].nil?
+        if options[:tag_set]
+
+            options[:tag_set].each do | tag |
+                attributes = {}
+                attributes[:resource_id] = subnet.subnet_id.to_s
+                attributes[:key] = tag[:key]
+                attributes[:value] = tag[:value]
+                new_tag = @compute.tags.new( attributes )
+                new_tag.save
+            end unless options[:tag_set].empty? or options[:tag_set].nil?
+
+        end
 
         @log.debug( subnet.inspect )
 


### PR DESCRIPTION
- Prints info output when including another file (essential for knowing which files have errors in)
- Removed strict requirement for private_ip_address in instance (if you have a network_interface, you don't need to specify this)
- Output the public IP that was assigned when creating network interfaces (saves going to the AWS console to find out)
- Ensure subnets can cope without tags
