### PR TITLE
Change to --config option to take multiple YAMLs

### DIFF
--- a/bin/build-cloud
+++ b/bin/build-cloud
@@ -33,7 +33,7 @@ options = {}
 optparse = OptionParser.new do |opts|
 
     options[:config] = nil
-    opts.on('-c', '--config=file', 'Config file path') do |c|
+    opts.on('-c', '--config file1,file2', Array, 'Config files - second and subsequent files merged into first.') do |c|
         options[:config] = c
     end
 
@@ -73,12 +73,12 @@ optparse = OptionParser.new do |opts|
     end
 
     options[:find_type] = []
-    opts.on('--find-type=t', 'Find objects by type') do |t|
+    opts.on('--find-type t', 'Find objects by type') do |t|
         options[:find_type].push(t.to_sym)
     end
 
     options[:find] = {}
-    opts.on('--find=f', 'Find objects by key match') do |f|
+    opts.on('--find f', 'Find objects by key match') do |f|
         args = f.split('=')
         options[:find][ args[0].to_sym ] = args[1]
     end

--- a/lib/build-cloud.rb
+++ b/lib/build-cloud.rb
@@ -15,9 +15,12 @@ class BuildCloud
 
         @log = options[:logger] or Logger.new( STDERR )
         @mock = options[:mock] or false
-        @config = YAML::load( File.open( options[:config] ) )
+        
+        first_config_file = options[:config].shift
 
-        include_files=Array.new
+        @config = YAML::load( File.open( first_config_file ) )
+
+        include_files = options[:config]
         if include_yaml = @config.delete(:include)
             if include_yaml.is_a?(Array)
                 include_files.concat(include_yaml)
@@ -28,7 +31,7 @@ class BuildCloud
         
         include_files.each do |include_file|
 
-            include_path = File.join( File.dirname( options[:config] ), include_file)
+            include_path = File.join( File.dirname( first_config_file ), include_file)
 
             if File.exists?( include_path )
                 @log.info( "Including YAML file #{include_path}" )


### PR DESCRIPTION
The second and subsequent files supplied to --config on the command line
are merged into the first, using the same mechanism for including files
within the YAML itself.
