### PR TITLE
Use pathname to discover full path for relative path includes

### DIFF
--- a/lib/build-cloud.rb
+++ b/lib/build-cloud.rb
@@ -3,6 +3,7 @@ require 'yaml'
 require 'pry'
 require 'logger'
 require 'pp'
+require 'pathname'
 
 class BuildCloud
 
@@ -31,12 +32,7 @@ class BuildCloud
         
         include_files.each do |include_file|
 
-            include_path = ''
-            if include_file.include? '/'
-                include_path = include_file
-            else
-                include_path = File.join( File.dirname( first_config_file ), include_file)
-            end
+            include_path = Pathname.new(File.join( File.dirname( first_config_file ), include_file)).realpath
 
             if File.exists?( include_path )
                 @log.info( "Including YAML file #{include_path}" )


### PR DESCRIPTION
This changes allows us to use relative paths in include files in the config, for example:

```
:include:
    - "../sec_groups.yaml"
    - "../common-mgmt.yaml"
    - "instances.yaml"
```

Results in output during run:

```
$ bundle exec build-cloud -c environment/euwest1-uat.yaml --create --find-type security_groups
I, [2014-10-09T07:55:18.991012 #26158]  INFO -- : Including YAML file /srv/data/repos/customer/repository/build-cloud/sec_groups.yaml
I, [2014-10-09T07:55:18.991908 #26158]  INFO -- : Including YAML file /srv/data/repos/customer/repository/build-cloud/common-app.yaml
I, [2014-10-09T07:55:18.992752 #26158]  INFO -- : Including YAML file /srv/data/repos/customer/repository/build-cloud/environment/instances.yaml
```

Which allows us to resolve paths that may be referenced with `.` or `..`
Without this change, any path referenced with `..` or `.` is not resolved correctly, and the config file referenced is ignored
