### PR TITLE
Fixes for IAM roles

### DIFF
--- a/lib/build-cloud.rb
+++ b/lib/build-cloud.rb
@@ -245,11 +245,12 @@ class BuildCloud
 
         @mock and Fog.mock!
 
-        fog_options = {
+        fog_options_regionless = {
             :aws_access_key_id     => @config[:aws_access_key_id] ||= ENV['AWS_ACCESS_KEY'],
             :aws_secret_access_key => @config[:aws_secret_access_key] ||= ENV['AWS_SECRET_KEY'],
-            :region                => @config[:aws_region],
         }
+
+        fog_options = fog_options_regionless.merge( { :region => @config[:aws_region] } )
 
         @fog_interfaces = {
 
@@ -257,14 +258,10 @@ class BuildCloud
             :s3          => Fog::Storage::AWS.new( fog_options ),
             :as          => Fog::AWS::AutoScaling.new( fog_options ),
             :elb         => Fog::AWS::ELB.new( fog_options ),
-            :iam         => Fog::AWS::IAM.new( fog_options ),
+            :iam         => Fog::AWS::IAM.new( fog_options_regionless ),
             :rds         => Fog::AWS::RDS.new( fog_options ),
             :elasticache => Fog::AWS::Elasticache.new( fog_options ),
-            :r53         => Fog::DNS::AWS.new(
-                :aws_access_key_id     => @config[:aws_access_key_id] ||= ENV['AWS_ACCESS_KEY'],
-                :aws_secret_access_key => @config[:aws_secret_access_key] ||= ENV['AWS_SECRET_KEY'],
-            )
-
+            :r53         => Fog::DNS::AWS.new( fog_options_regionless ) 
         }
 
     end

--- a/lib/build-cloud/iamrole.rb
+++ b/lib/build-cloud/iamrole.rb
@@ -36,6 +36,8 @@ class BuildCloud::IAMRole
 
         @log.debug( role.inspect )
 
+        @iam.create_instance_profile( @options[:rolename] )
+
         policies.each do |policy|
 
             @log.debug( "Adding policy #{policy}" )
@@ -45,10 +47,9 @@ class BuildCloud::IAMRole
             @iam.put_role_policy( @options[:rolename], policy[:policy_name],
                 policy_document )
 
-            @iam.create_instance_profile( @options[:rolename] )
-            @iam.add_role_to_instance_profile( @options[:rolename], @options[:rolename] )
-
         end
+
+        @iam.add_role_to_instance_profile( @options[:rolename], @options[:rolename] )
 
     end
 


### PR DESCRIPTION
As of https://github.com/fog/fog-aws/pull/102 Fog uses the region
argument to the IAM constructor, but this causes requests to blow up.
IAM is regionless, essentially, so doesn't need that.

Also moved instance profile creation outside of the policies loop so we
can properly support multiple policies per profile.