### PR TITLE
AWS environment variables fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ See the command line help for `build-cloud`.
 
 ## Changelog
 
+2015-09-02 - version 0.0.13 - use the same environment variables as AWS SDKs for credentials
+
 2015-08-24 - version 0.0.12 - adds support for tagging network interfaces, permits multiple config files to be passed on the commandline, fixes a bug with S3 buckets named to contain dots.
 
 2015-05-18 - version 0.0.11 - fixed problems with IAM roles

--- a/build-cloud.gemspec
+++ b/build-cloud.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "build-cloud"
-  spec.version       = "0.0.12"
+  spec.version       = "0.0.13"
   spec.authors       = ["The Scale Factory"]
   spec.email         = ["info@scalefactory.com"]
   spec.summary       = %q{Tools for building resources in AWS}

--- a/lib/build-cloud.rb
+++ b/lib/build-cloud.rb
@@ -61,7 +61,7 @@ class BuildCloud
                 include_files.push( File.expand_path( include_yaml, File.dirname( File.absolute_path(first_config_file) ) ) )
             end
         end
-        
+
         include_files.each do |include_path|
 
             if File.exists?( include_path )
@@ -201,7 +201,7 @@ class BuildCloud
     def self.search( type, options )
         BuildCloud::dispatch[type].search(options)
     end
-    
+
     def recursive_interpolate_config(h)
 
         # Work through the given config replacing all strings matching
@@ -228,7 +228,7 @@ class BuildCloud
                 else
                     raise "Attempt to interpolate with non-existant key '#{var}'"
                 end
-                
+
                 h.gsub!(/%\{#{var}\}/, val)
 
             end
@@ -246,8 +246,8 @@ class BuildCloud
         @mock and Fog.mock!
 
         fog_options_regionless = {
-            :aws_access_key_id     => @config[:aws_access_key_id] ||= ENV['AWS_ACCESS_KEY'],
-            :aws_secret_access_key => @config[:aws_secret_access_key] ||= ENV['AWS_SECRET_KEY'],
+            :aws_access_key_id     => @config[:aws_access_key_id] ||= ENV['AWS_ACCESS_KEY_ID'],
+            :aws_secret_access_key => @config[:aws_secret_access_key] ||= ENV['AWS_SECRET_ACCESS_KEY'],
         }
 
         fog_options = fog_options_regionless.merge( { :region => @config[:aws_region] } )
@@ -261,10 +261,9 @@ class BuildCloud
             :iam         => Fog::AWS::IAM.new( fog_options_regionless ),
             :rds         => Fog::AWS::RDS.new( fog_options ),
             :elasticache => Fog::AWS::Elasticache.new( fog_options ),
-            :r53         => Fog::DNS::AWS.new( fog_options_regionless ) 
+            :r53         => Fog::DNS::AWS.new( fog_options_regionless )
         }
 
     end
 
 end
-


### PR DESCRIPTION
Use the same AWS credential environment variables as the SDKs and CLI:
`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`