### PR TITLE
Added support for defaults in var interpolation

### DIFF
--- a/lib/build-cloud.rb
+++ b/lib/build-cloud.rb
@@ -222,32 +222,22 @@ class BuildCloud
             h.map { |v| recursive_interpolate_config(v) }
         when String
 
-            while h =~ /%\{(.+?)\}/
-                exp = $1
+            while /%\{(?<var>[^\|\}?]*)(?:\|{2}(?<default>[^\}]*))?\}/ =~ h
 
-                var = ""
+                exp = $&
                 val = ""
-                default = ""
-
-                if exp =~ /\|\|/
-                    (var, default) = exp.split('||')
-                else
-                    var = exp
-                end
 
                 if @config.has_key?(var.to_sym)
                     val = @config[var.to_sym]
                 else
-                    if default.nil?
-                        raise "Non-existent key '#{var}' supplied and default not defined after ||"
-                    elsif default.empty?
-                        raise "Attempt to interpolate with non-existant key '#{var}'"
+                    if default.empty?
+                        raise "Attempt to interpolate with non-existant key '#{var}' with no default value set"
                     else
                         val = default
                     end
                 end
 
-                h.gsub!(/%\{#{Regexp.escape(exp)}\}/, val)
+                h.gsub!(exp, val)
 
             end
 

--- a/lib/build-cloud.rb
+++ b/lib/build-cloud.rb
@@ -225,17 +225,9 @@ class BuildCloud
             while /%\{(?<var>[^\|\}]*)(?:\|{2}(?<default>[^\}]*))?\}/ =~ h
 
                 exp = $&
-                val = ""
 
-                if @config.has_key?(var.to_sym)
-                    val = @config[var.to_sym]
-                else
-                    if default.empty?
-                        raise "Attempt to interpolate with non-existant key '#{var}' with no default value set"
-                    else
-                        val = default
-                    end
-                end
+                val = @config.fetch(var.to_sym, default)
+                raise "Attempt to interpolate with non-existant key '#{var}' with no default value set" if val.nil?
 
                 h.gsub!(exp, val)
 

--- a/lib/build-cloud.rb
+++ b/lib/build-cloud.rb
@@ -224,6 +224,7 @@ class BuildCloud
 
             while /%\{(?<var>[^\|\}]*)(?:\|{2}(?<default>[^\}]*))?\}/ =~ h
 
+                # $& is the whole matched expression above, $MATCH when using English
                 exp = $&
 
                 val = @config.fetch(var.to_sym, default)

--- a/lib/build-cloud.rb
+++ b/lib/build-cloud.rb
@@ -222,7 +222,7 @@ class BuildCloud
             h.map { |v| recursive_interpolate_config(v) }
         when String
 
-            while /%\{(?<var>[^\|\}?]*)(?:\|{2}(?<default>[^\}]*))?\}/ =~ h
+            while /%\{(?<var>[^\|\}]*)(?:\|{2}(?<default>[^\}]*))?\}/ =~ h
 
                 exp = $&
                 val = ""


### PR DESCRIPTION
Allows you to say %{foo||bar} in a template, and if :foo is not defined, it will use "bar" as the value.

Intended for use in overriding instance sizes, for example:

%{monitoring_box_instance_type||t2.large}