### PR TITLE
Fix cache parameter group creation

### DIFF
--- a/lib/build-cloud/cacheparametergroup.rb
+++ b/lib/build-cloud/cacheparametergroup.rb
@@ -29,12 +29,7 @@ class BuildCloud::CacheParameterGroup
 
         @log.debug( param_group.inspect )
 
-        params = @elasticache.modify_cache_parameter_group options[:id], options[:params].collect! { |c| 
-            {
-                'ParameterName' => c[:param_name],
-                'ParameterValue' => c[:param_value],
-            }
-        }
+        params = @elasticache.modify_cache_parameter_group options[:id], options[:params]
 
         @log.debug( params.inspect )
 


### PR DESCRIPTION
The fog modify_cache_parameter_group interface is different to the
modify_db_parameter_group interface. The elasticache one expects a hash
whereas the db one expects an array.