### PR TITLE
launchconfigurations not comparing correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+2016-10-18 - version 0.0.22 - Fix launch configuration error where drives are different in config to fog.
+
 2016-07-22 - version 0.0.21 - Add support for replacing changed ASG Launch Configurations
 
 2016-07-08 - version 0.0.20 - Add support for creating Users, Groups and lifecycle management of their policies. Add support for creating and deleting custom Managed Policies, no lifecycle support for policy versions. Improve IAM role support, lifecycle support for policies: now removes and updates role policies if they change/removed. Add policy lifecycle to S3 buckets.

--- a/build-cloud.gemspec
+++ b/build-cloud.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "build-cloud"
-  spec.version       = "0.0.21"
+  spec.version       = "0.0.22"
   spec.authors       = ["The Scale Factory"]
   spec.email         = ["info@scalefactory.com"]
   spec.summary       = %q{Tools for building resources in AWS}


### PR DESCRIPTION
In some circumstances build cloud would not create or review launch configurations, these included user_data with certain characters or with nested volume options.