### PR TITLE
Fix role read.

### DIFF
--- a/lib/build-cloud/iamrole.rb
+++ b/lib/build-cloud/iamrole.rb
@@ -47,7 +47,7 @@ class BuildCloud::IAMRole
     end
 
     def read
-        @iam.roles.select { |r| r.rolename == @options[:rolename] }.first
+        @iam.roles.get(@options[:rolename])
     end
     
     


### PR DESCRIPTION
cc. @MrPrimate, @sftim 

When the AWS account has > 100 roles then the select will fail returning 

```
Empty Fog::AWS::IAM::Roles
```

even when the role exists. Possibly due to Fog paginating the results? 

That then causes build-cloud to fail when attempting to create the existing role:

```
$ bin/bc-create-app-env -c rs.workangel.com -v test -e test -p basic_redundant
...
bundler: failed to load command: build-cloud (/Users/markchalloner/Vagrant/wa/wa-infrastructure/support/aws-buildcloud/vendor/bundle/ruby/2.4.0/bin/build-cloud)
Fog::AWS::IAM::EntityAlreadyExists: Role with name sf_mongo_role already exists.
```

A side benefit is that this should also be more efficient.