### PR TITLE
Use zone.record.get for Route53 lookups

### DIFF
--- a/lib/build-cloud/r53recordset.rb
+++ b/lib/build-cloud/r53recordset.rb
@@ -86,9 +86,8 @@ class BuildCloud::R53RecordSet
 
     def read
         if zone
-            return zone.records.select { |r| r.name == @options[:name] }.first
+           zone.records.get @options[:name]
         end
-        nil
     end
 
     alias_method :fog_object, :read


### PR DESCRIPTION
This allows `build-cloud` to handle zones with more than 100 RecordSets

Using `record.get` avoids the need to handle paging.