### PR TITLE
Tag management: add missing tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
+2018-04-12 - version 1.1.3 - EC2 instances and ASG now add missing tags.
+
 2018-04-12 - version 1.1.2 - version bump.
 
-2018-04-12 - version 1.0.1 - VPC's now lifecycle tags.
+2018-04-12 - version 1.0.1 - VPC's now add missing tags.
 
 2017-11-13 - version 0.0.24 - Fix a bug which prevented working with IAM roles in AWS accounts with more than 100 roles. Thank you @markchalloner!
 

--- a/build-cloud.gemspec
+++ b/build-cloud.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "build-cloud"
-  spec.version       = "1.1.2"
+  spec.version       = "1.1.3"
   spec.authors       = ["The Scale Factory"]
   spec.email         = ["info@scalefactory.com"]
   spec.summary       = %q{Tools for building resources in AWS}

--- a/lib/build-cloud/vpc.rb
+++ b/lib/build-cloud/vpc.rb
@@ -50,7 +50,7 @@ class BuildCloud::VPC
         end
 
 
-        @log.info( "Creating new VPC for #{@options[:cidr_block]}" )
+        @log.info( "Creating new VPC for #{options[:cidr_block]}" )
 
         vpc = @compute.vpcs.new( options )
         vpc.save
@@ -93,9 +93,11 @@ class BuildCloud::VPC
     end
 
     def create_tags(tags)
-        if tags != fog_object.tags
-            @log.info("Updating tags")
-            @compute.create_tags( fog_object.id, tags )
+        # force symbols to strings in yaml tags
+        resolved_tags = fog_object.tags.dup.merge(tags.collect{|k,v| [k.to_s, v]}.to_h)
+        if resolved_tags != fog_object.tags
+            @log.info("Updating tags for VPC #{fog_object.id}")
+            @ec2.create_tags( fog_object.id, tags )
         end
     end
 


### PR DESCRIPTION
ASG and Instances will now add missing tags (it will not remove any additional tags)

VPC tag addition improved to only run when new tags.

connected to https://github.com/scalefactory/readyscale/issues/4394