### PR TITLE
subnets: add missing tag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+2018-06-18 - version 1.1.4 - Subnets now add missing tags.
+
 2018-04-12 - version 1.1.3 - EC2 instances and ASG now add missing tags.
 
 2018-04-12 - version 1.1.2 - version bump.

--- a/build-cloud.gemspec
+++ b/build-cloud.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "build-cloud"
-  spec.version       = "1.1.3"
+  spec.version       = "1.1.4"
   spec.authors       = ["The Scale Factory"]
   spec.email         = ["info@scalefactory.com"]
   spec.summary       = %q{Tools for building resources in AWS}


### PR DESCRIPTION
For sf-readyscale sf_data module to work, we need to be able to add missing tags to subnets