### PR TITLE
VPC tags use correct resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+2018-06-18 - version 1.1.6 - VPC tag addition now uses correct resource
+
 2018-06-18 - version 1.1.5 - Security groups now add missing tags.
 
 2018-06-18 - version 1.1.4 - Subnets now add missing tags.

--- a/build-cloud.gemspec
+++ b/build-cloud.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "build-cloud"
-  spec.version       = "1.1.5"
+  spec.version       = "1.1.6"
   spec.authors       = ["The Scale Factory"]
   spec.email         = ["info@scalefactory.com"]
   spec.summary       = %q{Tools for building resources in AWS}

--- a/lib/build-cloud/vpc.rb
+++ b/lib/build-cloud/vpc.rb
@@ -97,7 +97,7 @@ class BuildCloud::VPC
         resolved_tags = fog_object.tags.dup.merge(tags.collect{|k,v| [k.to_s, v]}.to_h)
         if resolved_tags != fog_object.tags
             @log.info("Updating tags for VPC #{fog_object.id}")
-            @ec2.create_tags( fog_object.id, tags )
+            @compute.create_tags( fog_object.id, tags )
         end
     end
 


### PR DESCRIPTION
the @ec2 object may not always exist depending o the order of components called, correct the vpc resource to use the local compute resource when creating new tags, as it should have done.