### PR TITLE
Handle more than 1 page of IAM policies

### DIFF
--- a/lib/build-cloud/iammanagedpolicy.rb
+++ b/lib/build-cloud/iammanagedpolicy.rb
@@ -38,8 +38,12 @@ class BuildCloud::IAMManagedPolicy
 
     end
 
+    # Fog only partly implements collection behaviour for managed policies
+    # Work around this using each() - and not, for example, select()
     def read
-        @iam.managed_policies.select { |r| r.name == @options[:name] }.first
+        @iam.managed_policies.each do |item|
+            return item if item.name == @options[:name]
+        end
     end
 
     alias_method :fog_object, :read


### PR DESCRIPTION
[Fog](http://fog.io/) partially takes care of pagination for managed IAM policies.

Make sure to use a method - `each` - where the pagination is accounted for. The previous implementation used `select` which only considered the first page of results.